### PR TITLE
cmake: Use proper variables for install paths

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,8 +44,8 @@ endif()
 set_target_properties(v4l2sink PROPERTIES PREFIX "")
 
 install(TARGETS v4l2sink
-	LIBRARY DESTINATION ${CMAKE_INSTALL_PREFIX}/lib/obs-plugins)
+	LIBRARY DESTINATION ${LIB_INSTALL_DIR}/obs-plugins)
 
 install(DIRECTORY locale/
-	DESTINATION "${CMAKE_INSTALL_PREFIX}/share/obs/obs-plugins/v4l2sink/locale")
+	DESTINATION "${SHARE_INSTALL_PREFIX}/obs/obs-plugins/v4l2sink/locale")
 


### PR DESCRIPTION
Hello,

I am trying to create an rpm package for this. On some system, using ${CMAKE_INSTALL_PREFIX} is not enough (eg Fedora has libs for x86_64 in /usr/lib64). Therefore use ${SHARE_INSTALL_PREFIX} and ${LIB_INSTALL_DIR} specifically.