### PR TITLE
Added compile instruction for Fedora/RHEL/CentOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,11 +59,15 @@ sudo make install
 
 If you are compiling this on Fedora, I would suggest installing the following dependencies inside a `toolbox` ([here](https://fedoramagazine.org/a-quick-introduction-to-toolbox-on-fedora/) you can learn more about it)
 
+- QT Development, the package has the following name:
+    - `qt5-qtbase-devel`
+
 - `Development Tools` group (install with `sudo yum groupinstall "Development Tools"`)
-    - `make`
+
+- The following packages are not included in the Development Tools group, but are required:
     - `cmake`
-    - `gcc`
-- `qt5-qtbase-devel`
+    - `g++`
+
 - RPM Fusion Free ([here](https://rpmfusion.org/Configuration) you can learn how to enable this repository)
     - `obs-studio-libs`
     - `obs-studio-devel`

--- a/README.md
+++ b/README.md
@@ -57,14 +57,14 @@ sudo make install
 
 #### Dependencies
 
-If you are compiling this on Fedora, I hardly recommend to install all the dependencies inside a container with the aid of `toolbox`
+If you are compiling this on Fedora, I would suggest installing the following dependencies inside a `toolbox` ([here](https://fedoramagazine.org/a-quick-introduction-to-toolbox-on-fedora/) you can learn more about it)
 
-- `Development Tools` group
+- `Development Tools` group (install with `sudo yum groupinstall "Development Tools"`)
     - `make`
     - `cmake`
     - `gcc`
 - `qt5-qtbase-devel`
-- RPM Fusion Free
+- RPM Fusion Free ([here](https://rpmfusion.org/Configuration) you can learn how to enable this repository)
     - `obs-studio-libs`
     - `obs-studio-devel`
 
@@ -92,10 +92,10 @@ The plugin will be installed inside `~/.config/obs-studio/plugins`
 
 #### Flatpak OBS
 
-If you are using Flatpak's OBS version, copy the plugin's files inside the application folder:
+If you are using the Flatpak OBS version, copy the plugin's files into the application folder:
 
 ```bash
 sudo cp -r $HOME/.config/obs-studio/plugins/v4l2sink/* /var/lib/flatpak/app/com.obsproject.Studio/x86_64/stable/active/files/
 ```
 
-Open OBS and navigate to the "Tools" drop-down: you will now see the V4L2 video output
+Open OBS and navigate to the "Tools" drop-down: you should now see the V4L2 video output

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ issue #17][vcam#17].
 
 [run-v4l2loopback]: https://github.com/umlaeute/v4l2loopback#run
 
-## Build
+## Build [Debian]
 
 - Install QT
 
@@ -52,3 +52,50 @@ cmake -DLIBOBS_INCLUDE_DIR="../../obs-studio/libobs" -DCMAKE_INSTALL_PREFIX=/usr
 make -j4
 sudo make install
 ```
+
+## Build [RHEL/CentOS]
+
+#### Dependencies
+
+If you are compiling this on Fedora, I hardly recommend to install all the dependencies inside a container with the aid of `toolbox`
+
+- `Development Tools` group
+    - `make`
+    - `cmake`
+    - `gcc`
+- `qt5-qtbase-devel`
+- RPM Fusion Free
+    - `obs-studio-libs`
+    - `obs-studio-devel`
+
+
+#### Build
+
+Download sources and prepare the build files
+
+```bash
+git clone --recursive https://github.com/obsproject/obs-studio.git
+git clone https://github.com/CatxFish/obs-v4l2sink.git
+cd obs-v4l2sink
+mkdir build && cd build
+```
+
+Compile and install the plugin
+
+```bash
+cmake -DLIBOBS_INCLUDE_DIR="../../obs-studio/libobs" -DCMAKE_INSTALL_PREFIX=/usr -DLIBOBS_LIB="/usr/lib64/libobs.so.0" -DCMAKE_INSTALL_PREFIX="${HOME}/.config/obs-studio/plugins/v4l2sink" ..
+make -j4
+make install
+```
+
+The plugin will be installed inside `~/.config/obs-studio/plugins`
+
+#### Flatpak OBS
+
+If you are using Flatpak's OBS version, copy the plugin's files inside the application folder:
+
+```bash
+sudo cp -r $HOME/.config/obs-studio/plugins/v4l2sink/* /var/lib/flatpak/app/com.obsproject.Studio/x86_64/stable/active/files/
+```
+
+Open OBS and navigate to the "Tools" drop-down: you will now see the V4L2 video output


### PR DESCRIPTION
Hi, do you mind to include these build instructions for Fedora/RHEL/CentOS based distros? I tested it on Fedora 31 and CentOS 8, and your plug in works like a charm on those.