### PR TITLE
fix compile warning: return value from v4l2device_close

### DIFF
--- a/src/v4l2sink.cpp
+++ b/src/v4l2sink.cpp
@@ -213,7 +213,7 @@ int v4l2device_open(void *data)
 static bool v4l2device_close(void *data)
 {
 	v4l2sink_data *out_data = (v4l2sink_data*)data;
-	close(out_data->v4l2_fd);
+	return close(out_data->v4l2_fd) == 0;
 }
 
 static const char *v4l2sink_getname(void *unused)


### PR DESCRIPTION
The return value here isn't used, but this currently warns:

```
src/v4l2sink.cpp:217:1: warning: no return statement in function returning non-void [-Wreturn-type]
```