### PR TITLE
Fix install location of plugin

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,7 +44,7 @@ endif()
 set_target_properties(v4l2sink PROPERTIES PREFIX "")
 
 install(TARGETS v4l2sink
-	LIBRARY DESTINATION ${CMAKE_INSTALL_PREFIX}/lib/obs-plugins)
+	LIBRARY DESTINATION ${LIBRARY_OUTPUT_PATH}/obs-plugins)
 
 install(DIRECTORY locale/
 	DESTINATION "${CMAKE_INSTALL_PREFIX}/share/obs/obs-plugins/v4l2sink/locale")


### PR DESCRIPTION
This improves the install location of the shared object. For example on systems where this should be `/usr/lib64/obs-plugins/`, this change picks up the right path.