### PR TITLE
Fixed warning: no return statement in function returning non-void

### DIFF
--- a/src/v4l2sink.cpp
+++ b/src/v4l2sink.cpp
@@ -214,6 +214,7 @@ static bool v4l2device_close(void *data)
 {
 	v4l2sink_data *out_data = (v4l2sink_data*)data;
 	close(out_data->v4l2_fd);
+	return true;
 }
 
 static const char *v4l2sink_getname(void *unused)


### PR DESCRIPTION
Compiling obs-v4l2sink generates the following message:

$ make -j4
Scanning dependencies of target v4l2sink_autogen
[ 20%] Automatic MOC and UIC for target v4l2sink
[ 20%] Built target v4l2sink_autogen
Scanning dependencies of target v4l2sink
[ 40%] Building CXX object CMakeFiles/v4l2sink.dir/v4l2sink_autogen/mocs_compilation.cpp.o
[ 60%] Building CXX object CMakeFiles/v4l2sink.dir/src/v4l2sink.cpp.o
[ 80%] Building CXX object CMakeFiles/v4l2sink.dir/src/v4l2sinkproperties.cpp.o
/home/gwolf/obs/obs-v4l2sink/src/v4l2sink.cpp: In function ‘bool v4l2device_close(void*)’:
/home/gwolf/obs/obs-v4l2sink/src/v4l2sink.cpp:217:1: warning: no return statement in function returning non-void [-Wreturn-type]
  217 | }
      | ^
[100%] Linking CXX shared module v4l2sink.so
[100%] Built target v4l2sink

This simple patch fixes it.
