### PR TITLE
Combine QT and LibOBS install into one apt command

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,16 +30,10 @@ issue #17][vcam#17].
 
 ## Build
 
-- Install QT
+- Install QT and LibObs
 
 ```
-sudo apt install qtbase5-dev
-```
-
-- Install LibObs
-
-```
-sudo apt install libobs-dev
+sudo apt install qtbase5-dev libobs-dev
 ```
 
 - Get obs-studio source code


### PR DESCRIPTION
This change updates the readme to recommend installing both apt-based dependencies simultaneously via a single apt command. This is more efficient and makes the overall setup slightly simpler.